### PR TITLE
Fix various tags not being a list

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -93,7 +93,7 @@ resource "google_compute_instance_template" "consul_server_private" {
   instance_description = "${var.cluster_description}"
   machine_type = "${var.machine_type}"
 
-  tags = "${concat(list(var.cluster_tag_name), var.custom_tags)}"
+  tags = ["${concat(list(var.cluster_tag_name), var.custom_tags)}"]
   metadata_startup_script = "${var.startup_script}"
   metadata = "${merge(map(var.metadata_key_name_for_cluster_size, var.cluster_size), var.custom_metadata)}"
 
@@ -180,7 +180,7 @@ resource "google_compute_firewall" "allow_inboud_http_api" {
   }
 
   source_ranges = "${var.allowed_inbound_cidr_blocks_http_api}"
-  source_tags = "${var.allowed_inbound_tags_http_api}"
+  source_tags = ["${var.allowed_inbound_tags_http_api}"]
   target_tags = ["${var.cluster_tag_name}"]
 }
 
@@ -210,7 +210,7 @@ resource "google_compute_firewall" "allow_inbound_dns" {
   }
 
   source_ranges = "${var.allowed_inbound_cidr_blocks_dns}"
-  source_tags = "${var.allowed_inbound_tags_dns}"
+  source_tags = ["${var.allowed_inbound_tags_dns}"]
   target_tags = ["${var.cluster_tag_name}"]
 }
 


### PR DESCRIPTION
When attempting to use the variables `cluster_tag_name`, `allowed_inbound_tags_api`, or `allowed_inbound_tags_dns` I would get errors from Terraform about the tags not being a list. This PR fixes that issue.

I also have a similar PR open for hashicorp/terraform-google-vault#2.