### PR TITLE
Add support for custom subnetworks

### DIFF
--- a/modules/consul-cluster/README.md
+++ b/modules/consul-cluster/README.md
@@ -333,7 +333,7 @@ the `startup_script` property.
 
 This module assumes you've already created your network topology (VPC, subnetworks, route tables, etc). By default,
 it will use the "default" network for the Project you select, but you may specify custom networks via the `network_name`
-property.
+and `subnetwork_name` properties.
 
 
 ### DNS entries

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -62,7 +62,8 @@ resource "google_compute_instance_template" "consul_server_public" {
   }
 
   network_interface {
-    network = "${var.network_name}"
+    network    = "${var.subnetwork_name != "" ? "" : var.network_name}"
+    subnetwork = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
     access_config {
       # The presence of this property assigns a public IP address to each Compute Instance. We intentionally leave it
       # blank so that an external IP address is selected automatically.
@@ -110,7 +111,8 @@ resource "google_compute_instance_template" "consul_server_private" {
   }
 
   network_interface {
-    network = "${var.network_name}"
+    network =    "${var.subnetwork_name != "" ? "" : var.network_name}"
+    subnetwork = "${var.subnetwork_name != "" ? var.subnetwork_name : ""}"
   }
 
   service_account {

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -58,7 +58,7 @@ variable "network_name" {
 }
 
 variable "subnetwork_name" {
-  description = "The name of the VPC Subnetwork where all resources should be created"
+  description = "The name of the VPC Subnetwork where all resources should be created. Defaults to the default subnetwork for the network and region."
   default = ""
 }
 

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -57,6 +57,11 @@ variable "network_name" {
   default = "default"
 }
 
+variable "subnetwork_name" {
+  description = "The name of the VPC Subnetwork where all resources should be created"
+  default = ""
+}
+
 variable "custom_tags" {
   description = "A list of tags that will be added to the Compute Instance Template in addition to the tags automatically added by this module."
   type = "list"


### PR DESCRIPTION
This should add in support for custom subnetworks while still supporting any of the older flows. A standard custom network still works, and a custom subnetwork will also work.

Fixes #4 