### PR TITLE
Define $HOME when running Consul on supervisord

### DIFF
--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -114,7 +114,7 @@ function create_consul_user {
     echo "User $username already exists. Will not create again."
   else
     log_info "Creating user named $username"
-    sudo useradd "$username"
+    sudo useradd --create-home "$username"
   fi
 }
 

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -202,7 +202,9 @@ function generate_supervisor_config {
   local readonly consul_log_dir="$4"
   local readonly consul_bin_dir="$5"
   local readonly consul_user="$6"
-  local readonly consul_user_home_dir="$(get_owner_home_dir $consul_user)"
+
+  local consul_user_home_dir=""
+  consul_user_home_dir="$(get_owner_home_dir $consul_user)"
 
   log_info "Creating Supervisor config file to run Consul in $supervisor_config_path"
   cat > "$supervisor_config_path" <<EOF
@@ -215,6 +217,8 @@ autostart=true
 autorestart=true
 stopsignal=INT
 user=$consul_user
+# Per Supervisord docs (http://supervisord.org/configuration.html), when supervisord runs a process it does not start a
+# login shell and does not change environment variables like USER or HOME, so we must pass this in manually.
 environment=HOME="$consul_user_home_dir"
 EOF
 }
@@ -233,7 +237,16 @@ function get_owner_of_path {
 
 function get_owner_home_dir {
   local readonly user="$1"
-  su - $user -c 'echo $HOME'
+
+  local home_dir=""
+  home_dir=$(sudo su - $user -c 'echo $HOME')
+
+  if [[ "$home_dir" == "/" ]]; then
+    log_error "No \$HOME directory is set for user $user. This may cause unpredictable behavior with Consul in GCP. Exiting."
+    exit 1
+  fi
+
+  echo "$home_dir"
 }
 
 function run {

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -202,6 +202,7 @@ function generate_supervisor_config {
   local readonly consul_log_dir="$4"
   local readonly consul_bin_dir="$5"
   local readonly consul_user="$6"
+  local readonly consul_user_home_dir="$(get_owner_home_dir $consul_user)"
 
   log_info "Creating Supervisor config file to run Consul in $supervisor_config_path"
   cat > "$supervisor_config_path" <<EOF
@@ -214,6 +215,7 @@ autostart=true
 autorestart=true
 stopsignal=INT
 user=$consul_user
+environment=HOME="$consul_user_home_dir"
 EOF
 }
 
@@ -227,6 +229,11 @@ function start_consul {
 function get_owner_of_path {
   local readonly path="$1"
   ls -ld "$path" | awk '{print $3}'
+}
+
+function get_owner_home_dir {
+  local readonly user="$1"
+  su - $user -c 'echo $HOME'
 }
 
 function run {


### PR DESCRIPTION
Consul uses references to `$HOME` environment variables quite a bit, for example on [Google Cloud Platform retry-join](https://www.consul.io/docs/agent/options.html#authentication-amp-precedence-1) provider. By default supervisord [does not set it at all](http://supervisord.org/configuration.html) even if `user` is defined to a different user than root.

> The user will be changed using setuid only. This does not start a login shell and does not change environment variables like USER or HOME.

This means that by default Consul tries to read GCP auth file from `/.config/gcloud/application_default_credentials.json`.

This PR modifies supervisord auto-generated config to include a proper definition for `$HOME` environment variable. For a user generated by `useradd -d /opt/consul consul` the resulting config file looks like this:

```
[program:consul]
command=/opt/consul/bin/consul agent -config-dir /opt/consul/config -data-dir /opt/consul/data
stdout_logfile=/opt/consul/log/consul-stdout.log
stderr_logfile=/opt/consul/log/consul-error.log
numprocs=1
autostart=true
autorestart=true
stopsignal=INT
user=consul
environment=HOME="/opt/consul"
```