### PR TITLE
Update outputs to be compatible with Terraform 11.

### DIFF
--- a/modules/consul-cluster/outputs.tf
+++ b/modules/consul-cluster/outputs.tf
@@ -39,17 +39,17 @@ output "firewall_rule_intracluster_name" {
 }
 
 output "firewall_rule_inbound_http_url" {
-  value = "${google_compute_firewall.allow_inboud_http_api.self_link}"
+  value = "${element(concat(google_compute_firewall.allow_inboud_http_api.*.self_link, list("")), 0)}"
 }
 
 output "firewall_rule_inbound_http_name" {
-  value = "${google_compute_firewall.allow_inboud_http_api.name}"
+  value = "${element(concat(google_compute_firewall.allow_inboud_http_api.*.name, list("")), 0)}"
 }
 
 output "firewall_rule_inbound_dns_url" {
-  value = "${google_compute_firewall.allow_inbound_dns.self_link}"
+  value = "${element(concat(google_compute_firewall.allow_inbound_dns.*.self_link, list("")), 0)}"
 }
 
 output "firewall_rule_inbound_dns_name" {
-  value = "${google_compute_firewall.allow_inbound_dns.name}"
+  value = "${element(concat(google_compute_firewall.allow_inbound_dns.*.name, list("")), 0)}"
 }


### PR DESCRIPTION
Terraform 0.11.x introduced a backward-incompatible change that required that any Terraform resources with a `count` property set to `0` to output their values in a way that is valid HCL.

I'm making this change as a precursor to reviewing the open PRs so that those will pass my local tests as expected.