### PR TITLE
General Improvements

### DIFF
--- a/examples/consul-examples-helper/README.md
+++ b/examples/consul-examples-helper/README.md
@@ -9,3 +9,13 @@ This folder contains a helper script called `consul-examples-helper.sh` for work
 1. Print out some example commands you can run against your Consul servers.
 
 **NOTE: To use this script be sure that `assign_public_ip_addresses` is set to `true` for the Consul Server cluster.**
+
+## Usage
+
+1. `cd /path/to/terraform/config`
+
+   For example, if you're running the root example in this repo, you should be in the root folder of this repo.
+
+1. `/path/to/consul-examples-helper.sh`
+
+    For example, if you're in the root of this repo, run `./examples/consul-examples-helper/consul-examples-helper.sh`.

--- a/examples/consul-examples-helper/consul-examples-helper.sh
+++ b/examples/consul-examples-helper/consul-examples-helper.sh
@@ -150,8 +150,6 @@ function get_consul_server_property_values {
   local -r property_name="$4"
   local instances
 
-  cluster_tag_name=$(get_required_terraform_output "cluster_tag_name") || exit 1
-
   log_info "Fetching external IP addresses for Consul Server Compute Instances with tag \"$cluster_tag_name\""
 
   instances=$(gcloud compute instances list \

--- a/examples/consul-examples-helper/consul-examples-helper.sh
+++ b/examples/consul-examples-helper/consul-examples-helper.sh
@@ -125,9 +125,9 @@ function wait_for_all_consul_servers_to_register {
     log_info "Running 'consul members' command against server at IP address $server_ip"
     # Intentionally use local and readonly here so that this script doesn't exit if the consul members or grep commands
     # exit with an error.
-    local -r members=$(consul members -http-addr="$server_ip:8500")
-    local -r server_members=$(echo "$members" | grep "server")
-    local -r num_servers=$(echo "$server_members" | wc -l | tr -d ' ')
+    local members=$(consul members -http-addr="$server_ip:8500")
+    local server_members=$(echo "$members" | grep "server")
+    local num_servers=$(echo "$server_members" | wc -l | tr -d ' ')
 
     if [[ "$num_servers" -eq "$expected_num_servers" ]]; then
       log_info "All $expected_num_servers Consul servers have registered in the cluster!"

--- a/examples/consul-examples-helper/consul-examples-helper.sh
+++ b/examples/consul-examples-helper/consul-examples-helper.sh
@@ -52,7 +52,8 @@ function get_required_terraform_output {
   output_value=$(terraform output -no-color "$output_name")
 
   if [[ -z "$output_value" ]]; then
-    log_error "Unable to find a value for Terraform output $output_name"
+    log_error "Unable to find a value for Terraform output \"$output_name\"."
+    log_error "Are you running this command from the same folder from which you ran \"terraform apply\"?"
     exit 1
   fi
 
@@ -85,10 +86,10 @@ function get_all_consul_server_property_values {
   local cluster_tag_name
   local expected_num_servers
 
-  gcp_project=$(get_required_terraform_output "gcp_project")
-  gcp_zone=$(get_required_terraform_output "gcp_zone")
-  cluster_tag_name=$(get_required_terraform_output "cluster_tag_name")
-  expected_num_servers=$(get_required_terraform_output "cluster_size")
+  gcp_project=$(get_required_terraform_output "gcp_project") || exit 1
+  gcp_zone=$(get_required_terraform_output "gcp_zone") || exit 1
+  cluster_tag_name=$(get_required_terraform_output "cluster_tag_name") || exit 1
+  expected_num_servers=$(get_required_terraform_output "cluster_size") || exit 1
 
   log_info "Looking up $server_property_name for $expected_num_servers Consul server Compute Instances."
 
@@ -116,7 +117,7 @@ function wait_for_all_consul_servers_to_register {
   local readonly server_ip="${server_ips[0]}"
 
   local expected_num_servers
-  expected_num_servers=$(get_required_terraform_output "cluster_size")
+  expected_num_servers=$(get_required_terraform_output "cluster_size") || exit 1
 
   log_info "Waiting for $expected_num_servers Consul servers to register in the cluster"
 
@@ -149,7 +150,7 @@ function get_consul_server_property_values {
   local readonly property_name="$4"
   local instances
 
-  cluster_tag_name=$(get_required_terraform_output "cluster_tag_name")
+  cluster_tag_name=$(get_required_terraform_output "cluster_tag_name") || exit 1
 
   log_info "Fetching external IP addresses for Consul Server Compute Instances with tag \"$cluster_tag_name\""
 

--- a/examples/consul-examples-helper/consul-examples-helper.sh
+++ b/examples/consul-examples-helper/consul-examples-helper.sh
@@ -15,29 +15,29 @@ readonly MAX_RETRIES=30
 readonly SLEEP_BETWEEN_RETRIES_SEC=10
 
 function log {
-  local readonly level="$1"
-  local readonly message="$2"
-  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+  local -r level="$1"
+  local -r message="$2"
+  local -r timestamp=$(date +"%Y-%m-%d %H:%M:%S")
   >&2 echo -e "${timestamp} [${level}] [$SCRIPT_NAME] ${message}"
 }
 
 function log_info {
-  local readonly message="$1"
+  local -r message="$1"
   log "INFO" "$message"
 }
 
 function log_warn {
-  local readonly message="$1"
+  local -r message="$1"
   log "WARN" "$message"
 }
 
 function log_error {
-  local readonly message="$1"
+  local -r message="$1"
   log "ERROR" "$message"
 }
 
 function assert_is_installed {
-  local readonly name="$1"
+  local -r name="$1"
 
   if [[ ! $(command -v ${name}) ]]; then
     log_error "The binary '$name' is required by this script but is not installed or in the system's PATH."
@@ -46,7 +46,7 @@ function assert_is_installed {
 }
 
 function get_required_terraform_output {
-  local readonly output_name="$1"
+  local -r output_name="$1"
   local output_value
 
   output_value=$(terraform output -no-color "$output_name")
@@ -71,9 +71,9 @@ function get_required_terraform_output {
 #   Returns: "A, B, C"
 #
 function join {
-  local readonly separator="$1"
+  local -r separator="$1"
   shift
-  local readonly values=("$@")
+  local -r values=("$@")
 
   printf "%s$separator" "${values[@]}" | sed "s/$separator$//"
 }
@@ -113,8 +113,8 @@ function get_all_consul_server_property_values {
 }
 
 function wait_for_all_consul_servers_to_register {
-  local readonly server_ips=($@)
-  local readonly server_ip="${server_ips[0]}"
+  local -r server_ips=($@)
+  local -r server_ip="${server_ips[0]}"
 
   local expected_num_servers
   expected_num_servers=$(get_required_terraform_output "cluster_size") || exit 1
@@ -125,9 +125,9 @@ function wait_for_all_consul_servers_to_register {
     log_info "Running 'consul members' command against server at IP address $server_ip"
     # Intentionally use local and readonly here so that this script doesn't exit if the consul members or grep commands
     # exit with an error.
-    local readonly members=$(consul members -http-addr="$server_ip:8500")
-    local readonly server_members=$(echo "$members" | grep "server")
-    local readonly num_servers=$(echo "$server_members" | wc -l | tr -d ' ')
+    local -r members=$(consul members -http-addr="$server_ip:8500")
+    local -r server_members=$(echo "$members" | grep "server")
+    local -r num_servers=$(echo "$server_members" | wc -l | tr -d ' ')
 
     if [[ "$num_servers" -eq "$expected_num_servers" ]]; then
       log_info "All $expected_num_servers Consul servers have registered in the cluster!"
@@ -144,10 +144,10 @@ function wait_for_all_consul_servers_to_register {
 }
 
 function get_consul_server_property_values {
-  local readonly gcp_project="$1"
-  local readonly gcp_zone="$2"
-  local readonly cluster_tag_name="$3"
-  local readonly property_name="$4"
+  local -r gcp_project="$1"
+  local -r gcp_zone="$2"
+  local -r cluster_tag_name="$3"
+  local -r property_name="$4"
   local instances
 
   cluster_tag_name=$(get_required_terraform_output "cluster_tag_name") || exit 1
@@ -168,8 +168,8 @@ function get_all_consul_server_ips {
 }
 
 function print_instructions {
-  local readonly server_ips=($@)
-  local readonly server_ip="${server_ips[0]}"
+  local -r server_ips=($@)
+  local -r server_ip="${server_ips[0]}"
 
   local instructions=()
   instructions+=("\nYour Consul servers are running at the following IP addresses:\n\n${server_ips[@]/#/    }\n")

--- a/examples/consul-image/consul.json
+++ b/examples/consul-image/consul.json
@@ -21,6 +21,13 @@
   },{
     "type": "shell",
     "inline": [
+      "sudo mkdir -p /opt/gruntwork",
+      "git clone --branch v0.0.3 https://github.com/gruntwork-io/bash-commons.git /tmp/bash-commons",
+      "sudo cp -r /tmp/bash-commons/modules/bash-commons/src /opt/gruntwork/bash-commons"
+    ]
+  },{
+    "type": "shell",
+    "inline": [
       "/tmp/terraform-google-consul/modules/install-consul/install-consul --version {{user `consul_version`}}",
       "/tmp/terraform-google-consul/modules/install-dnsmasq/install-dnsmasq"
     ],

--- a/examples/consul-image/consul.json
+++ b/examples/consul-image/consul.json
@@ -3,7 +3,7 @@
   "variables": {
     "project_id": null,
     "zone": null,
-    "consul_version": "0.9.3"
+    "consul_version": "1.1.0"
   },
   "builders": [{
     "type": "googlecompute",

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -78,12 +78,12 @@ function install_dependencies {
 }
 
 function user_exists {
-  local readonly username="$1"
+  local -r username="$1"
   id "$username" >/dev/null 2>&1
 }
 
 function create_consul_user {
-  local readonly username="$1"
+  local -r username="$1"
 
   if $(user_exists "$username"); then
     echo "User $username already exists. Will not create again."
@@ -94,8 +94,8 @@ function create_consul_user {
 }
 
 function create_consul_install_paths {
-  local readonly path="$1"
-  local readonly username="$2"
+  local -r path="$1"
+  local -r username="$2"
 
   log_info "Creating install dirs for Consul at $path"
   sudo mkdir -p "$path"
@@ -109,15 +109,15 @@ function create_consul_install_paths {
 }
 
 function install_binaries {
-  local readonly version="$1"
-  local readonly path="$2"
-  local readonly username="$3"
+  local -r version="$1"
+  local -r path="$2"
+  local -r username="$3"
 
-  local readonly url="https://releases.hashicorp.com/consul/${version}/consul_${version}_linux_amd64.zip"
-  local readonly download_path="/tmp/consul_${version}_linux_amd64.zip"
-  local readonly bin_dir="$path/bin"
-  local readonly consul_dest_path="$bin_dir/consul"
-  local readonly run_consul_dest_path="$bin_dir/run-consul"
+  local -r url="https://releases.hashicorp.com/consul/${version}/consul_${version}_linux_amd64.zip"
+  local -r download_path="/tmp/consul_${version}_linux_amd64.zip"
+  local -r bin_dir="$path/bin"
+  local -r consul_dest_path="$bin_dir/consul"
+  local -r run_consul_dest_path="$bin_dir/run-consul"
 
   log_info "Downloading Consul $version from $url to $download_path"
   curl -o "$download_path" "$url"
@@ -128,7 +128,7 @@ function install_binaries {
   sudo chown "$username:$username" "$consul_dest_path"
   sudo chmod a+x "$consul_dest_path"
 
-  local readonly symlink_path="$SYSTEM_BIN_DIR/consul"
+  local -r symlink_path="$SYSTEM_BIN_DIR/consul"
   if [[ -f "$symlink_path" ]]; then
     log_info "Symlink $symlink_path already exists. Will not add again."
   else

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -23,15 +23,18 @@ function print_usage {
   echo
   echo "This script can be used to install Consul and its dependencies. This script has been tested with Ubuntu 16.04."
   echo
-  echo "Options:"
+  echo "Required Arguments:"
   echo
-  echo -e "  --version\t\tThe version of Consul to install. Required."
+  echo -e "  --version\t\tThe version of Consul to install. Do not include a \"v\" in the version number"
+  echo
+  echo "Optional Arguments:"
+  echo
   echo -e "  --path\t\tThe path where Consul should be installed. Optional. Default: $DEFAULT_INSTALL_PATH."
   echo -e "  --user\t\tThe user who will own the Consul install directories. Optional. Default: $DEFAULT_CONSUL_USER."
   echo
   echo "Example:"
   echo
-  echo "  install-consul --version 0.8.0"
+  echo "  install-consul --version 1.1.0"
 }
 
 function log {

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -6,10 +6,15 @@
 
 set -e
 
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Include general-purpose bash functions from https://github.com/gruntwork-io/bash-commons. Assumes these were installed
+# separately from this script, for example, using "cd /opt/gruntwork && git clone https://github.com/gruntwork-io/bash-commons".
+source "/opt/gruntwork/bash-commons/assert.sh"
+source "/opt/gruntwork/bash-commons/log.sh"
+
 readonly DEFAULT_INSTALL_PATH="/opt/consul"
 readonly DEFAULT_CONSUL_USER="consul"
-
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SYSTEM_BIN_DIR="/usr/local/bin"
 
 readonly SUPERVISOR_DIR="/etc/supervisor"
@@ -35,39 +40,6 @@ function print_usage {
   echo "Example:"
   echo
   echo "  install-consul --version 1.1.0"
-}
-
-function log {
-  local readonly level="$1"
-  local readonly message="$2"
-  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
-  >&2 echo -e "${timestamp} [${level}] [$SCRIPT_NAME] ${message}"
-}
-
-function log_info {
-  local readonly message="$1"
-  log "INFO" "$message"
-}
-
-function log_warn {
-  local readonly message="$1"
-  log "WARN" "$message"
-}
-
-function log_error {
-  local readonly message="$1"
-  log "ERROR" "$message"
-}
-
-function assert_not_empty {
-  local readonly arg_name="$1"
-  local readonly arg_value="$2"
-
-  if [[ -z "$arg_value" ]]; then
-    log_error "The value for '$arg_name' cannot be empty"
-    print_usage
-    exit 1
-  fi
 }
 
 # Install steps are based on: http://unix.stackexchange.com/a/291098/215969

--- a/modules/install-dnsmasq/install-dnsmasq
+++ b/modules/install-dnsmasq/install-dnsmasq
@@ -33,30 +33,30 @@ function print_usage {
 }
 
 function log {
-  local readonly level="$1"
-  local readonly message="$2"
-  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+  local -r level="$1"
+  local -r message="$2"
+  local -r timestamp=$(date +"%Y-%m-%d %H:%M:%S")
   >&2 echo -e "${timestamp} [${level}] [$SCRIPT_NAME] ${message}"
 }
 
 function log_info {
-  local readonly message="$1"
+  local -r message="$1"
   log "INFO" "$message"
 }
 
 function log_warn {
-  local readonly message="$1"
+  local -r message="$1"
   log "WARN" "$message"
 }
 
 function log_error {
-  local readonly message="$1"
+  local -r message="$1"
   log "ERROR" "$message"
 }
 
 function assert_not_empty {
-  local readonly arg_name="$1"
-  local readonly arg_value="$2"
+  local -r arg_name="$1"
+  local -r arg_value="$2"
 
   if [[ -z "$arg_value" ]]; then
     log_error "The value for '$arg_name' cannot be empty"
@@ -70,7 +70,7 @@ function has_apt_get {
 }
 
 function install_dnsmasq {
-  local readonly consul_ip="$1"
+  local -r consul_ip="$1"
 
   log_info "Installing Dnsmasq"
 
@@ -84,9 +84,9 @@ function install_dnsmasq {
 }
 
 function write_consul_config {
-  local readonly consul_domain="$1"
-  local readonly consul_ip="$2"
-  local readonly consul_port="$3"
+  local -r consul_domain="$1"
+  local -r consul_ip="$2"
+  local -r consul_port="$3"
 
   log_info "Configuring Dnsmasq to forward lookups of the '$consul_domain' domain to $consul_ip:$consul_port in $CONSUL_DNS_MASQ_CONFIG_FILE"
   mkdir -p "$DNS_MASQ_CONFIG_DIR"

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -3,6 +3,12 @@
 
 set -e
 
+# Include general-purpose bash functions from https://github.com/gruntwork-io/bash-commons. Assumes these were installed
+# separately from this script, for example, using "cd /opt/gruntwork && git clone https://github.com/gruntwork-io/bash-commons".
+source "/opt/gruntwork/bash-commons/assert.sh"
+source "/opt/gruntwork/bash-commons/log.sh"
+source "/opt/gruntwork/bash-commons/string.sh"
+
 # In bash, we can't distinguish between the empty string, and no value at all, so we create our own unambiguous empty string.
 readonly EMPTY_VAL="__EMPTY__"
 
@@ -46,55 +52,6 @@ function print_usage {
   echo "Example:"
   echo
   echo "  run-consul --server --cluster-tag-name consul-xyz --config-dir /custom/path/to/consul/config"
-}
-
-function log {
-  local readonly level="$1"
-  local readonly message="$2"
-  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
-  >&2 echo -e "${timestamp} [${level}] [$SCRIPT_NAME] ${message}"
-}
-
-function log_info {
-  local readonly message="$1"
-  log "INFO" "$message"
-}
-
-function log_warn {
-  local readonly message="$1"
-  log "WARN" "$message"
-}
-
-function log_error {
-  local readonly message="$1"
-  log "ERROR" "$message"
-}
-
-# Based on code from: http://stackoverflow.com/a/16623897/483528
-function strip_prefix {
-  local readonly str="$1"
-  local readonly prefix="$2"
-  echo "${str#$prefix}"
-}
-
-function assert_is_installed {
-  local readonly name="$1"
-
-  if [[ ! $(command -v ${name}) ]]; then
-    log_error "The binary '$name' is required by this script but is not installed or in the system's PATH."
-    exit 1
-  fi
-}
-
-function assert_not_empty {
-  local readonly arg_name="$1"
-  local readonly arg_value="$2"
-
-  if [[ -z "$arg_value" ]]; then
-    log_error "The value for '$arg_name' cannot be empty"
-    print_usage
-    exit 1
-  fi
 }
 
 # Get the value at a specific Instance Metadata path.

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -56,7 +56,7 @@ function print_usage {
 
 # Get the value at a specific Instance Metadata path.
 function get_instance_metadata_value {
-  local readonly path="$1"
+  local -r path="$1"
 
   log_info "Looking up Metadata value at $COMPUTE_INSTANCE_METADATA_URL/$path"
   curl --silent --show-error --location --header "$GOOGLE_CLOUD_METADATA_REQUEST_HEADER" "$COMPUTE_INSTANCE_METADATA_URL/$path"
@@ -64,7 +64,7 @@ function get_instance_metadata_value {
 
 # Get the value of the given Custom Metadata Key
 function get_instance_custom_metadata_value {
-  local readonly key="$1"
+  local -r key="$1"
 
   log_info "Looking up Custom Instance Metadata value for key \"$key\""
   get_instance_metadata_value "instance/attributes/$key"
@@ -105,14 +105,14 @@ function get_instance_ip_address {
 }
 
 function generate_consul_config {
-  local readonly server="$1"
-  local readonly raft_protocol="$2"
-  local readonly config_dir="$3"
-  local readonly user="$4"
-  local readonly cluster_tag_name="$5"
-  local readonly cluster_size_instance_metadata_key_name="$6"
-  local readonly encrypt_key="$7"
-  local readonly config_path="$config_dir/$CONSUL_CONFIG_FILE"
+  local -r server="$1"
+  local -r raft_protocol="$2"
+  local -r config_dir="$3"
+  local -r user="$4"
+  local -r cluster_tag_name="$5"
+  local -r cluster_size_instance_metadata_key_name="$6"
+  local -r encrypt_key="$7"
+  local -r config_path="$config_dir/$CONSUL_CONFIG_FILE"
 
   local instance_ip_address=""
   local instance_name=""
@@ -163,12 +163,12 @@ EOF
 }
 
 function generate_supervisor_config {
-  local readonly supervisor_config_path="$1"
-  local readonly consul_config_dir="$2"
-  local readonly consul_data_dir="$3"
-  local readonly consul_log_dir="$4"
-  local readonly consul_bin_dir="$5"
-  local readonly consul_user="$6"
+  local -r supervisor_config_path="$1"
+  local -r consul_config_dir="$2"
+  local -r consul_data_dir="$3"
+  local -r consul_log_dir="$4"
+  local -r consul_bin_dir="$5"
+  local -r consul_user="$6"
 
   local consul_user_home_dir=""
   consul_user_home_dir="$(get_owner_home_dir $consul_user)"
@@ -198,12 +198,12 @@ function start_consul {
 
 # Based on: http://unix.stackexchange.com/a/7732/215969
 function get_owner_of_path {
-  local readonly path="$1"
+  local -r path="$1"
   ls -ld "$path" | awk '{print $3}'
 }
 
 function get_owner_home_dir {
-  local readonly user="$1"
+  local -r user="$1"
 
   local home_dir=""
   home_dir=$(sudo su - $user -c 'echo $HOME')


### PR DESCRIPTION
This PR:

- Cleans up the help text of `run-consul`.
- Replaces generic bash functions in our scripts with bash functions backed by automated tests from the [Gruntwork Bash Commons repo](https://github.com/gruntwork-io/bash-commons)
- Improves error messages in the helper script in case users attempt to execute the helper script in a directory other than the one from which they ran `terraform apply`.
- Fixes #14.
- Sets Consul 1.1.0 as the default Consul version in the Packer template example.