### PR TITLE
Bring variable access closer to vault_cluster module

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -72,7 +72,8 @@ resource "google_compute_instance_template" "consul_server_public" {
   }
 
   service_account {
-    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+    email   = "${var.service_account_email}"
+    scopes  = ["userinfo-email", "compute-ro", "storage-ro"]
   }
 
   # Per Terraform Docs (https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager),
@@ -116,7 +117,8 @@ resource "google_compute_instance_template" "consul_server_private" {
   }
 
   service_account {
-    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+    email   = "${var.service_account_email}"
+    scopes  = ["userinfo-email", "compute-ro", "storage-ro"]
   }
 
   # Per Terraform Docs (https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager),

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -77,7 +77,7 @@ resource "google_compute_instance_template" "consul_server_public" {
       list(
         "userinfo-email", 
         "compute-ro", 
-        "${var.storage_access}"
+        "var.storage_access"
       ),
       var.service_account_scopes
     )}"]
@@ -130,7 +130,7 @@ resource "google_compute_instance_template" "consul_server_private" {
       list(
         "userinfo-email", 
         "compute-ro", 
-        "${var.storage_access}"
+        "var.storage_access"
       ),
       var.service_account_scopes
     )}"]

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -73,7 +73,7 @@ resource "google_compute_instance_template" "consul_server_public" {
 
   service_account {
     email   = "${var.service_account_email}"
-    scopes  = ["userinfo-email", "compute-ro", "storage-ro"]
+    scopes  = ["userinfo-email", "compute-ro", "storage-rw"]
   }
 
   # Per Terraform Docs (https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager),
@@ -118,7 +118,7 @@ resource "google_compute_instance_template" "consul_server_private" {
 
   service_account {
     email   = "${var.service_account_email}"
-    scopes  = ["userinfo-email", "compute-ro", "storage-ro"]
+    scopes  = ["userinfo-email", "compute-ro", "storage-rw"]
   }
 
   # Per Terraform Docs (https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager),

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -79,7 +79,7 @@ resource "google_compute_instance_template" "consul_server_public" {
         "compute-ro", 
         "${var.storage_access}"
       )
-      var.service_account_scopes
+      ${var.service_account_scopes}
     )}"]
 
   }
@@ -132,7 +132,7 @@ resource "google_compute_instance_template" "consul_server_private" {
         "compute-ro", 
         "${var.storage_access}"
       )
-      var.service_account_scopes
+      ${var.service_account_scopes}
     )}"]
   }
 

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -73,8 +73,8 @@ resource "google_compute_instance_template" "consul_server_public" {
 
   service_account {
     email   = "${var.service_account_email}"
-    scopes  = ["${concat (
-      list (
+    scopes  = ["${concat(
+      list(
         "userinfo-email", 
         "compute-ro", 
         "${var.storage_access}"
@@ -126,8 +126,8 @@ resource "google_compute_instance_template" "consul_server_private" {
 
   service_account {
     email   = "${var.service_account_email}"
-    scopes  = ["${concat (
-      list (
+    scopes  = ["${concat(
+      list(
         "userinfo-email", 
         "compute-ro", 
         "${var.storage_access}"

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -77,7 +77,7 @@ resource "google_compute_instance_template" "consul_server_public" {
       list(
         "userinfo-email", 
         "compute-ro", 
-        "var.storage_access"
+        "${var.storage_access}"
       ),
       var.service_account_scopes
     )}"]
@@ -130,7 +130,7 @@ resource "google_compute_instance_template" "consul_server_private" {
       list(
         "userinfo-email", 
         "compute-ro", 
-        "var.storage_access"
+        "${var.storage_access}"
       ),
       var.service_account_scopes
     )}"]

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -73,7 +73,7 @@ resource "google_compute_instance_template" "consul_server_public" {
 
   service_account {
     email   = "${var.service_account_email}"
-    scopes  = ["userinfo-email", "compute-ro", "{$var.storage_access}"]
+    scopes  = ["userinfo-email", "compute-ro", "${var.storage_access}"]
   }
 
   # Per Terraform Docs (https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager),

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -73,7 +73,7 @@ resource "google_compute_instance_template" "consul_server_public" {
 
   service_account {
     email   = "${var.service_account_email}"
-    scopes  = ["userinfo-email", "compute-ro", "storage-rw"]
+    scopes  = ["userinfo-email", "compute-ro", "{$var.storage_access}"]
   }
 
   # Per Terraform Docs (https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager),

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -78,8 +78,8 @@ resource "google_compute_instance_template" "consul_server_public" {
         "userinfo-email", 
         "compute-ro", 
         "${var.storage_access}"
-      )
-      ${var.service_account_scopes}
+      ),
+      var.service_account_scopes
     )}"]
 
   }
@@ -131,8 +131,8 @@ resource "google_compute_instance_template" "consul_server_private" {
         "userinfo-email", 
         "compute-ro", 
         "${var.storage_access}"
-      )
-      ${var.service_account_scopes}
+      ),
+      var.service_account_scopes
     )}"]
   }
 

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -118,7 +118,7 @@ resource "google_compute_instance_template" "consul_server_private" {
 
   service_account {
     email   = "${var.service_account_email}"
-    scopes  = ["userinfo-email", "compute-ro", "storage-rw"]
+    scopes  = ["userinfo-email", "compute-ro", "${var.storage_access}"]
   }
 
   # Per Terraform Docs (https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager),

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -73,7 +73,15 @@ resource "google_compute_instance_template" "consul_server_public" {
 
   service_account {
     email   = "${var.service_account_email}"
-    scopes  = ["userinfo-email", "compute-ro", "${var.storage_access}"]
+    scopes  = ["${concat (
+      list (
+        "userinfo-email", 
+        "compute-ro", 
+        "${var.storage_access}"
+      )
+      var.service_account_scopes
+    )}"]
+
   }
 
   # Per Terraform Docs (https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager),
@@ -118,7 +126,14 @@ resource "google_compute_instance_template" "consul_server_private" {
 
   service_account {
     email   = "${var.service_account_email}"
-    scopes  = ["userinfo-email", "compute-ro", "${var.storage_access}"]
+    scopes  = ["${concat (
+      list (
+        "userinfo-email", 
+        "compute-ro", 
+        "${var.storage_access}"
+      )
+      var.service_account_scopes
+    )}"]
   }
 
   # Per Terraform Docs (https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#using-with-instance-group-manager),

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -38,7 +38,7 @@ variable "startup_script" {
 
 variable "service_account_scopes" {
   description = "A list of service account scopes that will be added to the Compute Instance Template in addition to the scopes automatically added by this module."
-  type = list
+  type = "list"
   default = []
 }
 

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -36,6 +36,12 @@ variable "startup_script" {
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "service_account_scopes" {
+  description = "A list of service account scopes that will be added to the Compute Instance Template in addition to the scopes automatically added by this module."
+  type = list
+  default = []
+}
+
 variable "storage_access" {
   description = "Used to set the access permissions for GCE storage"
   default = "storage-ro"

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -38,7 +38,7 @@ variable "startup_script" {
 
 variable "storage_access" {
   description = "Used to set the access permissions for GCE storage"
-  default = "storage-ro"
+  default = ""
 }
 
 variable "instance_group_target_pools" {

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -68,6 +68,11 @@ variable "custom_tags" {
   default = []
 }
 
+variable "service_account_email" {
+  description = "The email of the service account for the instance template. If none is provided the google cloud provider project service account is used."
+  default     = ""
+}
+
 variable "instance_group_update_strategy" {
   description = "The update strategy to be used by the Instance Group. IMPORTANT! When you update almost any cluster setting, under the hood, this module creates a new Instance Group Template. Once that Instance Group Template is created, the value of this variable determines how the new Template will be rolled out across the Instance Group. Unfortunately, as of August 2017, Google only supports the options 'RESTART' (instantly restart all Compute Instances and launch new ones from the new Template) or 'NONE' (do nothing; updates should be handled manually). Google does offer a rolling updates feature that perfectly meets our needs, but this is in Alpha (https://goo.gl/MC3mfc). Therefore, until this module supports a built-in rolling update strategy, we recommend using `NONE` and using the alpha rolling updates strategy to roll out new Consul versions. As an alpha feature, be sure you are comfortable with the level of risk you are taking on. For additional detail, see https://goo.gl/hGH6dd."
   default = "NONE"

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -36,6 +36,11 @@ variable "startup_script" {
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "storage_access" {
+  description = "Used to set the access permissions for GCE storage"
+  default = "storage-ro"
+}
+
 variable "instance_group_target_pools" {
   description = "To use a Load Balancer with the Consul cluster, you must populate this value. Specifically, this is the list of Target Pool URLs to which new Compute Instances in the Instance Group created by this module will be added. Note that updating the Target Pools attribute does not affect existing Compute Instances. Note also that use of a Load Balancer with Consul is generally discouraged; client should instead prefer to talk directly to the server where possible."
   type = "list"

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -38,7 +38,7 @@ variable "startup_script" {
 
 variable "storage_access" {
   description = "Used to set the access permissions for GCE storage"
-  default = ""
+  default = "storage-ro"
 }
 
 variable "instance_group_target_pools" {


### PR DESCRIPTION
Added: 
- `service_account_email` variable, so the service account for the VMs can be defined
- `storage_access` variable, so storage access permissions can be changed
- `service_account_scopes` variable, so additional scopes can be defined

This makes the variables available in `consul_cluster` closer to those available in `vault_cluster` of `terraform-google-vault`, allowing for a more consistent approach when deploying both