### PR TITLE
Switch from a single-zone Managed Instance Group to a Multi-Zonal Group

### DIFF
--- a/examples/consul-image/consul.json
+++ b/examples/consul-image/consul.json
@@ -3,7 +3,7 @@
   "variables": {
     "project_id": null,
     "zone": null,
-    "consul_version": "1.1.0"
+    "consul_version": "1.2.2"
   },
   "builders": [{
     "type": "googlecompute",

--- a/examples/root-example/README.md
+++ b/examples/root-example/README.md
@@ -36,3 +36,12 @@ To deploy a Consul Cluster:
    print out the IP addresses of the Consul servers and some example commands you can run to interact with the cluster:
    `../consul-examples-helper/consul-examples-helper.sh`.
 
+### WARNING: This example exposes your cluster to the public Internet!
+
+This example enables your Consul Client and Consul Server to be accessible from `0.0.0.0/0` (any IP address) by default.
+This is not an acceptable security posture in a production setting! In a production setting, you should set the
+`allowed_inbound_cidr_blocks_http_api` property of the [consul-cluster](
+https://github.com/hashicorp/terraform-google-consul/tree/master/modules/consul-cluster) module to either an empty list
+or a limited range of IP addresses.
+
+Note that for access within GCP, using the `allowed_inbound_tags_http_api` module property is preferred.

--- a/main.tf
+++ b/main.tf
@@ -7,8 +7,8 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 provider "google" {
-  project     = "${var.gcp_project}"
-  region      = "${var.gcp_region}"
+  project = "${var.gcp_project}"
+  region  = "${var.gcp_region}"
 }
 
 terraform {
@@ -25,18 +25,18 @@ module "consul_servers" {
   # source = "git::git@github.com:gruntwork-io/consul-gcp-module.git//modules/consul-cluster?ref=v0.0.1"
   source = "./modules/consul-cluster"
 
-  gcp_zone = "${var.gcp_zone}"
-  cluster_name = "${var.consul_server_cluster_name}"
+  gcp_region          = "${var.gcp_region}"
+  cluster_name        = "${var.consul_server_cluster_name}"
   cluster_description = "Consul Server cluster"
-  cluster_size = "${var.consul_server_cluster_size}"
-  cluster_tag_name = "${var.consul_server_cluster_tag_name}"
-  startup_script = "${data.template_file.startup_script_server.rendered}"
+  cluster_size        = "${var.consul_server_cluster_size}"
+  cluster_tag_name    = "${var.consul_server_cluster_tag_name}"
+  startup_script      = "${data.template_file.startup_script_server.rendered}"
 
   # Grant API and DNS access to requests originating from the the Consul client cluster we create below.
-  allowed_inbound_tags_http_api = ["${var.consul_server_cluster_tag_name}"]
+  allowed_inbound_tags_http_api        = ["${var.consul_server_cluster_tag_name}"]
   allowed_inbound_cidr_blocks_http_api = "${var.consul_server_allowed_inbound_cidr_blocks_http_api}"
 
-  allowed_inbound_tags_dns = ["${var.consul_server_cluster_tag_name }"]
+  allowed_inbound_tags_dns        = ["${var.consul_server_cluster_tag_name }"]
   allowed_inbound_cidr_blocks_dns = "${var.consul_server_allowed_inbound_cidr_blocks_dns}"
 
   # WARNING! These configuration values are suitable for testing, but for production, see https://www.consul.io/docs/guides/performance.html
@@ -46,7 +46,8 @@ module "consul_servers" {
   # - root_volume_disk_type: pd-ssd or local-ssd (for write-heavy workloads, use SSDs for the best write throughput)
   # - root_volume_disk_size_gb: Consul's data set is persisted, so this depends on the size of your expected data set
   machine_type = "g1-small"
-  root_volume_disk_type = "pd-standard"
+
+  root_volume_disk_type    = "pd-standard"
   root_volume_disk_size_gb = "15"
 
   # WARNING! By specifying just the "family" name of the Image, Google will automatically use the latest Consul image.
@@ -87,21 +88,21 @@ module "consul_clients" {
   # source = "git::git@github.com:gruntwork-io/consul-gcp-module.git//modules/consul-cluster?ref=v0.0.1"
   source = "./modules/consul-cluster"
 
-  gcp_zone = "${var.gcp_zone}"
-  cluster_name = "${var.consul_client_cluster_name}"
+  gcp_region          = "${var.gcp_region}"
+  cluster_name        = "${var.consul_client_cluster_name}"
   cluster_description = "Consul Clients cluster"
-  cluster_size = "${var.consul_client_cluster_size}"
-  cluster_tag_name = "${var.consul_client_cluster_tag_name}"
-  startup_script = "${data.template_file.startup_script_client.rendered}"
+  cluster_size        = "${var.consul_client_cluster_size}"
+  cluster_tag_name    = "${var.consul_client_cluster_tag_name}"
+  startup_script      = "${data.template_file.startup_script_client.rendered}"
 
-  allowed_inbound_tags_http_api = ["${var.consul_client_cluster_tag_name}"]
+  allowed_inbound_tags_http_api        = ["${var.consul_client_cluster_tag_name}"]
   allowed_inbound_cidr_blocks_http_api = "${var.consul_client_allowed_inbound_cidr_blocks_http_api}"
 
-  allowed_inbound_tags_dns = ["${var.consul_client_cluster_tag_name }"]
+  allowed_inbound_tags_dns        = ["${var.consul_client_cluster_tag_name }"]
   allowed_inbound_cidr_blocks_dns = "${var.consul_client_allowed_inbound_cidr_blocks_dns}"
 
-  machine_type = "g1-small"
-  root_volume_disk_type = "pd-standard"
+  machine_type             = "g1-small"
+  root_volume_disk_type    = "pd-standard"
   root_volume_disk_size_gb = "15"
 
   assign_public_ip_addresses = true
@@ -109,7 +110,8 @@ module "consul_clients" {
   source_image = "${var.consul_client_source_image}"
 
   # Our Consul Clients are completely stateless, so we are free to destroy and re-create them as needed.
-  instance_group_update_strategy = "RESTART"
+  # Todo: Research this further
+  instance_group_update_strategy = "NONE"
 }
 
 # Render the Startup Script that will run on each Consul Server Instance on boot.

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -118,6 +118,8 @@ resource "google_compute_instance_template" "consul_server_private" {
     boot         = true
     auto_delete  = true
     source_image = "${var.source_image}"
+    disk_size_gb = "${var.root_volume_disk_size_gb}"
+    disk_type    = "${var.root_volume_disk_type}"
   }
 
   network_interface {

--- a/modules/consul-cluster/outputs.tf
+++ b/modules/consul-cluster/outputs.tf
@@ -1,5 +1,5 @@
-output "gcp_zone" {
-  value = "${var.gcp_zone}"
+output "gcp_region" {
+  value = "${var.gcp_region}"
 }
 
 output "cluster_name" {
@@ -11,11 +11,11 @@ output "cluster_tag_name" {
 }
 
 output "instance_group_url" {
-  value = "${google_compute_instance_group_manager.consul_server.self_link}"
+  value = "${google_compute_region_instance_group_manager.consul_server.self_link}"
 }
 
 output "instance_group_name" {
-  value = "${google_compute_instance_group_manager.consul_server.name}"
+  value = "${google_compute_region_instance_group_manager.consul_server.name}"
 }
 
 output "instance_template_url" {

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -3,8 +3,8 @@
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "gcp_zone" {
-  description = "All GCP resources will be launched in this Zone."
+variable "gcp_region" {
+  description = "All GCP resources will be launched in this Region."
 }
 
 variable "cluster_name" {
@@ -38,45 +38,45 @@ variable "startup_script" {
 
 variable "service_account_scopes" {
   description = "A list of service account scopes that will be added to the Compute Instance Template in addition to the scopes automatically added by this module."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "storage_access_scope" {
   description = "Used to set the access permissions for Google Cloud Storage. As of September 2018, this must be one of ['', 'storage-ro', 'storage-rw', 'storage-full']"
-  default = "storage-ro"
+  default     = "storage-ro"
 }
 
 variable "instance_group_target_pools" {
   description = "To use a Load Balancer with the Consul cluster, you must populate this value. Specifically, this is the list of Target Pool URLs to which new Compute Instances in the Instance Group created by this module will be added. Note that updating the Target Pools attribute does not affect existing Compute Instances. Note also that use of a Load Balancer with Consul is generally discouraged; client should instead prefer to talk directly to the server where possible."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "cluster_description" {
   description = "A description of the Consul cluster; it will be added to the Compute Instance Template."
-  default = ""
+  default     = ""
 }
 
 variable "assign_public_ip_addresses" {
   description = "If true, each of the Compute Instances will receive a public IP address and be reachable from the Public Internet (if Firewall rules permit). If false, the Compute Instances will have private IP addresses only. In production, this should be set to false."
-  default = false
+  default     = false
 }
 
 variable "network_name" {
   description = "The name of the VPC Network where all resources should be created."
-  default = "default"
+  default     = "default"
 }
 
 variable "subnetwork_name" {
   description = "The name of the VPC Subnetwork where all resources should be created. Defaults to the default subnetwork for the network and region."
-  default = ""
+  default     = ""
 }
 
 variable "custom_tags" {
   description = "A list of tags that will be added to the Compute Instance Template in addition to the tags automatically added by this module."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "service_account_email" {
@@ -86,86 +86,86 @@ variable "service_account_email" {
 
 variable "instance_group_update_strategy" {
   description = "The update strategy to be used by the Instance Group. IMPORTANT! When you update almost any cluster setting, under the hood, this module creates a new Instance Group Template. Once that Instance Group Template is created, the value of this variable determines how the new Template will be rolled out across the Instance Group. Unfortunately, as of August 2017, Google only supports the options 'RESTART' (instantly restart all Compute Instances and launch new ones from the new Template) or 'NONE' (do nothing; updates should be handled manually). Google does offer a rolling updates feature that perfectly meets our needs, but this is in Alpha (https://goo.gl/MC3mfc). Therefore, until this module supports a built-in rolling update strategy, we recommend using `NONE` and using the alpha rolling updates strategy to roll out new Consul versions. As an alpha feature, be sure you are comfortable with the level of risk you are taking on. For additional detail, see https://goo.gl/hGH6dd."
-  default = "NONE"
+  default     = "NONE"
 }
 
 variable "allowed_inbound_cidr_blocks_http_api" {
   description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow API connections to Consul."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "allowed_inbound_tags_http_api" {
   description = "A list of tags from which the Compute Instances will allow API connections to Consul."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "allowed_inbound_cidr_blocks_dns" {
   description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow TCP DNS and UDP DNS connections to Consul."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "allowed_inbound_tags_dns" {
   description = "A list of tags from which the Compute Instances will allow TCP DNS and UDP DNS connections to Consul."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 # Metadata
 
 variable "metadata_key_name_for_cluster_size" {
   description = "The key name to be used for the custom metadata attribute that represents the size of the Consul cluster."
-  default = "cluster-size"
+  default     = "cluster-size"
 }
 
 variable "custom_metadata" {
   description = "A map of metadata key value pairs to assign to the Compute Instance metadata."
-  type = "map"
-  default = {}
+  type        = "map"
+  default     = {}
 }
 
 # Firewall Ports
 
 variable "server_rpc_port" {
   description = "The port used by servers to handle incoming requests from other agents."
-  default = 8300
+  default     = 8300
 }
 
 variable "cli_rpc_port" {
   description = "The port used by all agents to handle RPC from the CLI."
-  default = 8400
+  default     = 8400
 }
 
 variable "serf_lan_port" {
   description = "The port used to handle gossip in the LAN. Required by all agents."
-  default = 8301
+  default     = 8301
 }
 
 variable "serf_wan_port" {
   description = "The port used by servers to gossip over the WAN to other servers."
-  default = 8302
+  default     = 8302
 }
 
 variable "http_api_port" {
   description = "The port used by clients to talk to the HTTP API"
-  default = 8500
+  default     = 8500
 }
 
 variable "dns_port" {
   description = "The port used to resolve DNS queries."
-  default = 8600
+  default     = 8600
 }
 
 # Disk Settings
 
 variable "root_volume_disk_size_gb" {
   description = "The size, in GB, of the root disk volume on each Consul node."
-  default = 30
+  default     = 30
 }
 
 variable "root_volume_disk_type" {
   description = "The GCE disk type. Can be either pd-ssd, local-ssd, or pd-standard"
-  default = "pd-standard"
+  default     = "pd-standard"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,49 +1,49 @@
 output "gcp_project" {
   description = "The GCP Project where all resources are deployed."
-  value = "${var.gcp_project}"
+  value       = "${var.gcp_project}"
 }
 
-output "gcp_zone" {
-  description = "The GCP Zone where all resources are deployed."
-  value = "${module.consul_servers.gcp_zone}"
+output "gcp_region" {
+  description = "The GCP region where all resources are deployed."
+  value       = "${module.consul_servers.gcp_region}"
 }
 
 output "cluster_size" {
   description = "The number of servers in the Consul Server cluster."
-  value = "${var.consul_server_cluster_size}"
+  value       = "${var.consul_server_cluster_size}"
 }
 
 output "cluster_tag_name" {
   description = "The tag assigned to each Consul Server node that is used to discover other Consul Server nodes."
-  value = "${var.consul_server_cluster_tag_name}"
+  value       = "${var.consul_server_cluster_tag_name}"
 }
 
 output "instance_group_name" {
   description = "The name of the Managed Instance Group that contains the Consul Server cluster."
-  value = "${module.consul_servers.instance_group_name}"
+  value       = "${module.consul_servers.instance_group_name}"
 }
 
 output "instance_group_url" {
   description = "The URL of the Managed Instance Group that contains the Consul Server cluster."
-  value = "${module.consul_servers.instance_group_url}"
+  value       = "${module.consul_servers.instance_group_url}"
 }
 
 output "client_instance_group_name" {
   description = "The name of the Managed Instance Group that contains the Consul Client cluster."
-  value = "${module.consul_clients.instance_group_name}"
+  value       = "${module.consul_clients.instance_group_name}"
 }
 
 output "instance_template_metadata_fingerprint" {
   description = "A hash computed by the unique combination of metadata associated with the Instance Template used by the Consul Server cluster."
-  value = "${module.consul_servers.instance_template_metadata_fingerprint}"
+  value       = "${module.consul_servers.instance_template_metadata_fingerprint}"
 }
 
 output "instance_template_name" {
   description = "The name of the Instance Template used by the Consul Server cluster."
-  value = "${module.consul_servers.instance_template_name}"
+  value       = "${module.consul_servers.instance_template_name}"
 }
 
 output "instance_template_url" {
   description = "The URL of the Instance Template used by the Consul Server cluster."
-  value = "${module.consul_servers.instance_template_url}"
+  value       = "${module.consul_servers.instance_template_url}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,7 +53,7 @@ variable "consul_client_cluster_size" {
 variable "consul_server_allowed_inbound_cidr_blocks_http_api" {
   description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow API connections to Consul."
   type        = "list"
-  default     = []
+  default     = ["0.0.0.0/0"]
 }
 
 variable "consul_server_allowed_inbound_cidr_blocks_dns" {
@@ -65,7 +65,7 @@ variable "consul_server_allowed_inbound_cidr_blocks_dns" {
 variable "consul_client_allowed_inbound_cidr_blocks_http_api" {
   description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow API connections to Consul."
   type        = "list"
-  default     = []
+  default     = ["0.0.0.0/0"]
 }
 
 variable "consul_client_allowed_inbound_cidr_blocks_dns" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,10 +11,6 @@ variable "gcp_region" {
   description = "The region in which all GCP resources will be launched."
 }
 
-variable "gcp_zone" {
-  description = "The region in which all GCP resources will be launched."
-}
-
 variable "consul_server_cluster_name" {
   description = "The name of the Consul Server cluster. All resources will be namespaced by this value. E.g. consul-server-prod"
 }
@@ -46,34 +42,34 @@ variable "consul_client_source_image" {
 
 variable "consul_server_cluster_size" {
   description = "The number of nodes to have in the Consul Server cluster. We strongly recommended that you use either 3 or 5."
-  default = 3
+  default     = 3
 }
 
 variable "consul_client_cluster_size" {
   description = "The number of nodes to have in the Consul Client example cluster. Any number of nodes is permissible, though 3 is usually enough to test.."
-  default = 3
+  default     = 3
 }
 
 variable "consul_server_allowed_inbound_cidr_blocks_http_api" {
   description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow API connections to Consul."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "consul_server_allowed_inbound_cidr_blocks_dns" {
   description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow TCP DNS and UDP DNS connections to Consul."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "consul_client_allowed_inbound_cidr_blocks_http_api" {
   description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow API connections to Consul."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "consul_client_allowed_inbound_cidr_blocks_dns" {
   description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow TCP DNS and UDP DNS connections to Consul."
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }


### PR DESCRIPTION
This PR switches from a single-zone Managed Instance Group to a Multi-Zonal Managed Instance Group. This way, Consul nodes launch in a diversity of physical data centers ("Zones") within a given region instead of all in a single data center (Zone).

This PR also:

- Fixes an issue where users could not specify the root disk type and size for "private" clusters.
- Updates to the latest version of Consul (v1.2.2)
- Enables access to the cluster via `0.0.0.0/0` by default (along with a hearty warning)

'cc @infosecgithub @bgt101

