### PR TITLE
Add fix for bug introduced in Terraform v0.11.8

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -53,7 +53,7 @@ resource "google_compute_instance_template" "consul_server_public" {
   disk {
     boot         = true
     auto_delete  = true
-    source_image = "${var.source_image}"
+    source_image = "${data.google_compute_image.image.self_link}"
     disk_size_gb = "${var.root_volume_disk_size_gb}"
     disk_type    = "${var.root_volume_disk_type}"
   }
@@ -114,7 +114,7 @@ resource "google_compute_instance_template" "consul_server_private" {
   disk {
     boot         = true
     auto_delete  = true
-    source_image = "${var.source_image}"
+    source_image = "${data.google_compute_image.image.self_link}"
     disk_size_gb = "${var.root_volume_disk_size_gb}"
     disk_type    = "${var.root_volume_disk_type}"
   }
@@ -255,4 +255,10 @@ data "template_file" "compute_instance_template_self_link" {
   # - Concat these lists. concat(list-of-1-value, empty-list) == list-of-1-value
   # - Take the first element of list-of-1-value
   template = "${element(concat(google_compute_instance_template.consul_server_public.*.self_link, google_compute_instance_template.consul_server_private.*.self_link), 0)}"
+}
+
+# This is a workaround for a provider bug in Terraform v0.11.8. For more information please refer to:
+# https://github.com/terraform-providers/terraform-provider-google/issues/2067.
+data "google_compute_image" "image" {
+  name = "${var.source_image}"
 }


### PR DESCRIPTION
This PR adds a fix for a bug introduced in Terraform v0.11.8. For more information please see: https://github.com/terraform-providers/terraform-provider-google/issues/2067.

## Steps to Reproduce

1. Install Terraform v0.11.8.
2. Checkout the `master` branch.
3. Run the automated tests from the `test` directory: `go test -v -timeout 60m -run TestConsulClusterWithUbuntuImage`.

### Result

```bash
TestConsulClusterWithUbuntuImage 2018-10-02T15:15:24+02:00 command.go:100: Error: Error refreshing state: 2 error(s) occurred:
TestConsulClusterWithUbuntuImage 2018-10-02T15:15:24+02:00 command.go:100:
TestConsulClusterWithUbuntuImage 2018-10-02T15:15:24+02:00 command.go:100: * module.consul_clients.google_compute_instance_template.consul_server_public: 1 error(s) occurred:
TestConsulClusterWithUbuntuImage 2018-10-02T15:15:24+02:00 command.go:100:
TestConsulClusterWithUbuntuImage 2018-10-02T15:15:24+02:00 command.go:100: * module.consul_clients.google_compute_instance_template.consul_server_public: google_compute_instance_template.consul_server_public: error flattening disks: Error getting relative path for source image: String was not a self link: global/images/consul-2018-10-02-010549
TestConsulClusterWithUbuntuImage 2018-10-02T15:15:24+02:00 command.go:100: * module.consul_servers.google_compute_instance_template.consul_server_public: 1 error(s) occurred:
TestConsulClusterWithUbuntuImage 2018-10-02T15:15:24+02:00 command.go:100:
TestConsulClusterWithUbuntuImage 2018-10-02T15:15:24+02:00 command.go:100: * module.consul_servers.google_compute_instance_template.consul_server_public: google_compute_instance_template.consul_server_public: error flattening disks: Error getting relative path for source image: String was not a self link: global/images/consul-2018-10-02-010549
TestConsulClusterWithUbuntuImage 2018-10-02T15:15:24+02:00 command.go:100:
TestConsulClusterWithUbuntuImage 2018-10-02T15:15:24+02:00 command.go:100:
TestConsulClusterWithUbuntuImage 2018-10-02T15:15:24+02:00 retry.go:77: Returning due to fatal error: FatalError{Underlying: exit status 1}
--- FAIL: TestConsulClusterWithUbuntuImage (583.07s)
    apply.go:13: FatalError{Underlying: exit status 1}
    destroy.go:11: FatalError{Underlying: exit status 1}
FAIL
exit status 1
FAIL    github.com/robmorgan/terraform-google-consul/test       583.101s
```

### Expected Result

```bash
PASS
ok      github.com/robmorgan/terraform-google-consul/test       836.258s
```
