### PR TITLE
Add image_project_id variable and change var.source_image to var.source_image_family

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,7 @@ module "consul_servers" {
   # In production, you should specify the exact image name to make it clear which image the current Consul servers are
   # deployed with.
   source_image = "${var.consul_server_source_image}"
+  image_project_id = "${var.consul_image_project_id}"
 
   # WARNING! This makes the Consul cluster accessible from the public Internet, which is convenient for testing, but
   # NOT for production usage. In production, set this to false.

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,8 @@ module "consul_servers" {
   # WARNING! By specifying just the "family" name of the Image, Google will automatically use the latest Consul image.
   # In production, you should specify the exact image name to make it clear which image the current Consul servers are
   # deployed with.
-  source_image = "${var.consul_server_source_image}"
+  source_image_family = "${var.consul_server_source_image_family}"
+
   image_project_id = "${var.consul_image_project_id}"
 
   # WARNING! This makes the Consul cluster accessible from the public Internet, which is convenient for testing, but
@@ -109,7 +110,7 @@ module "consul_clients" {
 
   assign_public_ip_addresses = true
 
-  source_image = "${var.consul_client_source_image}"
+  source_image_family = "${var.consul_client_source_image_family}"
 
   # Our Consul Clients are completely stateless, so we are free to destroy and re-create them as needed.
   # Todo: Research this further

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -273,5 +273,5 @@ data "template_file" "compute_instance_template_self_link" {
 # https://github.com/terraform-providers/terraform-provider-google/issues/2067.
 data "google_compute_image" "image" {
   name    = "${var.source_image}"
-  project = "${var.image_project_id != "" ? var.image_project_id : var.gcp_project_id}
+  project = "${var.image_project_id != "" ? var.image_project_id : var.gcp_project_id}"
 }

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -96,7 +96,7 @@ resource "google_compute_instance_template" "consul_server_public" {
 # Create the Instance Template that will be used to populate the Managed Instance Group.
 # NOTE: This Compute Instance Template is only created if var.assign_public_ip_addresses is false.
 resource "google_compute_instance_template" "consul_server_private" {
-  count   = "${1 - var.assign_public_ip_addresses}"
+  count = "${1 - var.assign_public_ip_addresses}"
 
   project = "${var.gcp_project_id}"
 
@@ -223,7 +223,7 @@ resource "google_compute_firewall" "allow_inbound_http_api" {
 # - Note that public access to your Consul Cluster will only be permitted if var.assign_public_ip_addresses is true.
 # - This Firewall Rule is only created if at least one source tag or source CIDR block is specified.
 resource "google_compute_firewall" "allow_inbound_dns" {
-  count   = "${length(var.allowed_inbound_cidr_blocks_dns) + length(var.allowed_inbound_tags_dns) > 0 ? 1 : 0}"
+  count = "${length(var.allowed_inbound_cidr_blocks_dns) + length(var.allowed_inbound_tags_dns) > 0 ? 1 : 0}"
 
   project = "${var.network_project_id != "" ? var.network_project_id : var.gcp_project_id}"
 
@@ -272,6 +272,6 @@ data "template_file" "compute_instance_template_self_link" {
 # This is a workaround for a provider bug in Terraform v0.11.8. For more information please refer to:
 # https://github.com/terraform-providers/terraform-provider-google/issues/2067.
 data "google_compute_image" "image" {
-  family    = "${var.source_image_family}"
-  project   = "${var.image_project_id != "" ? var.image_project_id : var.gcp_project_id}"
+  family  = "${var.source_image_family}"
+  project = "${var.image_project_id != "" ? var.image_project_id : var.gcp_project_id}"
 }

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -273,5 +273,5 @@ data "template_file" "compute_instance_template_self_link" {
 # https://github.com/terraform-providers/terraform-provider-google/issues/2067.
 data "google_compute_image" "image" {
   name    = "${var.source_image}"
-  project = "${var.gcp_project_id}"
+  project = "${var.image_project_id != "" ? var.image_project_id : var.gcp_project_id}
 }

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -40,9 +40,9 @@ variable "startup_script" {
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "image_project_id"{
+variable "image_project_id" {
   description = "The name of the GCP project where the image is located. Useful when using a project to store all custom images. If empty, var.gcp_project_id will be used."
-  default = ""
+  default     = ""
 }
 
 variable "network_project_id" {

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -40,6 +40,11 @@ variable "startup_script" {
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "image_project_id"{
+  description = "The name of the GCP project where the image is located. Useful when using a project to store all custom images. If empty, var.gcp_project_id will be used."
+  default = ""
+}
+
 variable "network_project_id" {
   description = "The name of the GCP Project where the network is located. Useful when using networks shared between projects. If empty, var.gcp_project_id will be used."
   default = ""

--- a/variables.tf
+++ b/variables.tf
@@ -27,11 +27,11 @@ variable "consul_client_cluster_tag_name" {
   description = "A tag that will uniquely identify the Consul Clients. In this example, the Consul Server cluster uses this tag to identify the Consul Client servers that should have query permissions."
 }
 
-variable "consul_server_source_image" {
+variable "consul_server_source_image_family" {
   description = "The Google Image used to launch each node in the Consul Server cluster."
 }
 
-variable "consul_client_source_image" {
+variable "consul_client_source_image_family" {
   description = "The Google Image used to launch each node in the Consul Client cluster."
 }
 
@@ -42,7 +42,7 @@ variable "consul_client_source_image" {
 
 variable "consul_image_project_id" {
   description = "The name of the GCP Project where the image is located. Useful when using a project to store custom images. If empty, var.gcp_project_id will be used."
-  default = ""
+  default     = ""
 }
 
 variable "network_project_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,11 @@ variable "consul_client_source_image" {
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "consul_image_project_id" {
+  description = "The name of the GCP Project where the image is located. Useful when using a project to store custom images. If empty, var.gcp_project_id will be used."
+  default = ""
+}
+
 variable "network_project_id" {
   description = "The name of the GCP Project where the network is located. Useful when using networks shared between projects. If empty, var.gcp_project_id will be used."
   default     = ""


### PR DESCRIPTION
This PR adds the `image_project_id` variable, allowing the user to specify the project from which the `source_image` is pulled. If this variable remains empty, the value in `gcp_project_id` is used. 

This PR also changes `google_compute_image.image` to use `family` rather than `name`. This allows newer custom images in the same family to be used without having to modify the terraform code.