### PR TITLE
Create image_project_id variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,8 @@ module "consul_servers" {
   # deployed with.
   source_image = "${var.consul_server_source_image}"
 
+  image_project_id = "${var.image_project_id}"
+
   # WARNING! This makes the Consul cluster accessible from the public Internet, which is convenient for testing, but
   # NOT for production usage. In production, set this to false.
   assign_public_ip_addresses = true
@@ -108,7 +110,8 @@ module "consul_clients" {
 
   assign_public_ip_addresses = true
 
-  source_image = "${var.consul_client_source_image}"
+  source_image     = "${var.consul_client_source_image}"
+  image_project_id = "${var.image_project_id}"
 
   # Our Consul Clients are completely stateless, so we are free to destroy and re-create them as needed.
   # Todo: Research this further

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -96,7 +96,7 @@ resource "google_compute_instance_template" "consul_server_public" {
 # Create the Instance Template that will be used to populate the Managed Instance Group.
 # NOTE: This Compute Instance Template is only created if var.assign_public_ip_addresses is false.
 resource "google_compute_instance_template" "consul_server_private" {
-  count   = "${1 - var.assign_public_ip_addresses}"
+  count = "${1 - var.assign_public_ip_addresses}"
 
   project = "${var.gcp_project_id}"
 
@@ -223,7 +223,7 @@ resource "google_compute_firewall" "allow_inbound_http_api" {
 # - Note that public access to your Consul Cluster will only be permitted if var.assign_public_ip_addresses is true.
 # - This Firewall Rule is only created if at least one source tag or source CIDR block is specified.
 resource "google_compute_firewall" "allow_inbound_dns" {
-  count   = "${length(var.allowed_inbound_cidr_blocks_dns) + length(var.allowed_inbound_tags_dns) > 0 ? 1 : 0}"
+  count = "${length(var.allowed_inbound_cidr_blocks_dns) + length(var.allowed_inbound_tags_dns) > 0 ? 1 : 0}"
 
   project = "${var.network_project_id != "" ? var.network_project_id : var.gcp_project_id}"
 
@@ -273,5 +273,5 @@ data "template_file" "compute_instance_template_self_link" {
 # https://github.com/terraform-providers/terraform-provider-google/issues/2067.
 data "google_compute_image" "image" {
   name    = "${var.source_image}"
-  project = "${var.gcp_project_id}"
+  project = "${var.image_project_id != "" ? var.image_project_id : var.gcp_project_id}"
 }

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -40,9 +40,14 @@ variable "startup_script" {
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "image_project_id" {
+  description = "The name of the GCP Project where the image is located. Useful when using a separate project for custom images. If empty, var.gcp_project_id will be used."
+  default     = ""
+}
+
 variable "network_project_id" {
   description = "The name of the GCP Project where the network is located. Useful when using networks shared between projects. If empty, var.gcp_project_id will be used."
-  default = ""
+  default     = ""
 }
 
 variable "service_account_scopes" {

--- a/variables.tf
+++ b/variables.tf
@@ -40,9 +40,14 @@ variable "consul_client_source_image" {
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "image_project_id" {
+  description = "The name of the GCP Project where the image is located. Useful when using a separate project for custom images. If empty, var.gcp_project_id will be used."
+  default     = ""
+}
+
 variable "network_project_id" {
   description = "The name of the GCP Project where the network is located. Useful when using networks shared between projects. If empty, var.gcp_project_id will be used."
-  default = ""
+  default     = ""
 }
 
 variable "consul_server_cluster_size" {


### PR DESCRIPTION
This PR creates an `image_project_id` variable to allow for specifying the project where the source image is located. This is useful on multi-project setups where an entire project may be dedicated to custom images. At present, only images within the project where the cluster is being deployed can be used.