### PR TITLE
Remove deprecated map function in preparation for Terraform 0.12

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -44,7 +44,7 @@ resource "google_compute_instance_template" "consul_server_public" {
 
   tags                    = "${concat(list(var.cluster_tag_name), var.custom_tags)}"
   metadata_startup_script = "${var.startup_script}"
-  metadata                = "${merge(map(var.metadata_key_name_for_cluster_size, var.cluster_size), var.custom_metadata)}"
+  metadata                = "${merge({var.metadata_key_name_for_cluster_size, var.cluster_size}, var.custom_metadata)}"
 
   scheduling {
     automatic_restart   = true


### PR DESCRIPTION
`map` will be [deprecated as of Terraform v0.12](https://www.terraform.io/docs/configuration/functions/map.html) and will get removed at some point thereafter.
`merge` alone appears to achieve what is needed https://www.terraform.io/docs/configuration/functions/merge.html

This *will* break backwards compatibility