### PR TITLE
 Add ubuntu 18.04 to the tests and examples

### DIFF
--- a/examples/consul-image/README.md
+++ b/examples/consul-image/README.md
@@ -3,7 +3,7 @@
 This folder shows an example of how to use the [install-consul](https://github.com/hashicorp/terraform-google-consul/tree/master/modules/install-consul) and
 [install-dnsmasq](https://github.com/hashicorp/terraform-google-consul/tree/master/modules/install-dnsmasq) modules with [Packer](https://www.packer.io/) to create [Custom Images](
 https://cloud.google.com/compute/docs/images) that have Consul and Dnsmasq installed on
-top of Ubuntu 16.04 LTS. At this time, Ubuntu 16.04 LTS is the only supported Linux distribution.
+top of Ubuntu. At this time, Ubuntu 16.04 and 18.04 LTS are the only supported Linux distributions.
 
 These Images will have [Consul](https://www.consul.io/) installed and configured to automatically join a cluster during
 boot-up. They also have [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) installed and configured to use

--- a/examples/consul-image/consul.json
+++ b/examples/consul-image/consul.json
@@ -6,18 +6,32 @@
     "consul_version": "1.2.2"
   },
   "builders": [{
+    "name": "ubuntu-16-image",
     "type": "googlecompute",
-    "image_name": "consul-{{isotime \"2006-01-02-030405\"}}",
+    "image_name": "consul-ubuntu16-{{isotime \"2006-01-02-030405\"}}",
     "image_family": "consul",
     "project_id": "{{user `project_id`}}",
     "source_image_family": "ubuntu-1604-lts",
     "zone": "{{user `zone`}}",
     "ssh_username": "ubuntu"
+  },
+  {
+    "name": "ubuntu-18-image",
+    "type": "googlecompute",
+    "image_name": "consul-ubuntu18-{{isotime \"2006-01-02-030405\"}}",
+    "image_family": "consul",
+    "project_id": "{{user `project_id`}}",
+    "source_image_family": "ubuntu-1804-lts",
+    "zone": "{{user `zone`}}",
+    "ssh_username": "ubuntu"
   }],
   "provisioners": [{
+    "type": "shell",
+    "inline": ["mkdir -p /tmp/terraform-google-consul/modules"]
+  },{
     "type": "file",
-    "source": "{{template_dir}}/../../../terraform-google-consul",
-    "destination": "/tmp"
+    "source": "{{template_dir}}/../../modules/",
+    "destination": "/tmp/terraform-google-consul/modules"
   },{
     "type": "shell",
     "inline": [

--- a/test/consul_cluster_test.go
+++ b/test/consul_cluster_test.go
@@ -4,8 +4,14 @@ import (
 	"testing"
 )
 
-// Test the example in the root folder
-func TestConsulClusterWithUbuntuImage(t *testing.T) {
+// Test the example in the root folder for Ubuntu 16.04
+func TestConsulClusterWithUbuntu16Image(t *testing.T) {
 	t.Parallel()
-	runConsulClusterTest(t, "googlecompute", ".", "../examples/consul-image/consul.json")
+	runConsulClusterTest(t, "ubuntu-16-image", ".", "../examples/consul-image/consul.json")
+}
+
+// Test the example in the root folder for Ubuntu 18.04
+func TestConsulClusterWithUbuntu18Image(t *testing.T) {
+	t.Parallel()
+	runConsulClusterTest(t, "ubuntu-18-image", ".", "../examples/consul-image/consul.json")
 }


### PR DESCRIPTION
This updates the packer template and tests to include ubuntu 18.04 alongside ubuntu 16.04.

* also added in an update to the packer template that speeds up upload by provisioning only the `/modules` folder