### PR TITLE
Allows to specify source_ranges for cluster traffic firewall rule

### DIFF
--- a/modules/consul-cluster/README.md
+++ b/modules/consul-cluster/README.md
@@ -276,7 +276,10 @@ This module creates Firewall rules that allow inbound requests as follows:
 
 * **Consul**: For all the [ports used by Consul](https://www.consul.io/docs/agent/options.html#ports), all members of 
   the Consul Server cluster will automatically accept inbound traffic based on a [tag](
-  https://cloud.google.com/compute/docs/vpc/add-remove-network-tags) shared by all cluster members.  
+  https://cloud.google.com/compute/docs/vpc/add-remove-network-tags) shared by all cluster members.
+  If necessary, you can use the `allowed_inbound_cidr_blocks_cluster` parameter to control the list of [CIDR blocks](
+  https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) where you want agents to be able to communicate with
+  the cluster (when network tag is not enough).
 
 * **External HTTP API Access**: For external access to the Consul Server cluster over the HTTP API port (default: 8500),
   you can use the `allowed_inbound_cidr_blocks_http_api` parameter to control the list of [CIDR blocks](

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -190,8 +190,9 @@ resource "google_compute_firewall" "allow_intracluster_consul" {
     ]
   }
 
-  source_tags = [var.cluster_tag_name]
-  target_tags = [var.cluster_tag_name]
+  source_ranges = var.allowed_inbound_cidr_blocks_cluster
+  source_tags   = [var.cluster_tag_name]
+  target_tags   = [var.cluster_tag_name]
 }
 
 # Specify which traffic is allowed into the Consul Cluster solely for HTTP API requests

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -120,6 +120,12 @@ variable "instance_group_update_strategy" {
   default     = "NONE"
 }
 
+variable "allowed_inbound_cidr_blocks_cluster" {
+  description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow cluster connections to Consul."
+  type        = list(string)
+  default     = []
+}
+
 variable "allowed_inbound_cidr_blocks_http_api" {
   description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow API connections to Consul."
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "consul_client_cluster_size" {
   default     = 3
 }
 
+variable "consul_server_allowed_inbound_cidr_blocks_cluster" {
+  description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow cluster connections to Consul."
+  type        = list(string)
+  default     = []
+}
+
 variable "consul_server_allowed_inbound_cidr_blocks_http_api" {
   description = "A list of CIDR-formatted IP address ranges from which the Compute Instances will allow API connections to Consul."
   type        = list(string)


### PR DESCRIPTION
This fixes https://github.com/hashicorp/terraform-google-consul/issues/45
Feel free to comment.