### PR TITLE
Add app version for GC Region Instance Group Manager

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -18,7 +18,9 @@ resource "google_compute_region_instance_group_manager" "consul_server" {
   name    = "${var.cluster_name}-ig"
 
   base_instance_name = var.cluster_name
-  instance_template  = data.template_file.compute_instance_template_self_link.rendered
+  version {
+    instance_template  = data.template_file.compute_instance_template_self_link.rendered
+  }
   region             = var.gcp_region
 
   # Consul Server is a stateful cluster, so the update strategy used to roll out a new GCE Instance Template must be


### PR DESCRIPTION
Signed-off-by: naiduarvind <arvind.naidu@mindvalley.com>

![Screenshot 2019-11-26 at 5 55 30 PM](https://user-images.githubusercontent.com/6829472/69619948-74813980-1077-11ea-8d61-f991f51b062f.png)

Without the version attribute present, `terraform plan` was not working as expected when deploying Vault referencing this module for Consul. Having this attribute for Vault fixed it hence creating this PR to ensure consistency for Consul - being the dependency module.