### PR TITLE
Update main.tf

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -21,10 +21,6 @@ resource "google_compute_region_instance_group_manager" "consul_server" {
   instance_template  = data.template_file.compute_instance_template_self_link.rendered
   region             = var.gcp_region
 
-  # Consul Server is a stateful cluster, so the update strategy used to roll out a new GCE Instance Template must be
-  # a rolling update. But since Terraform does not yet support ROLLING_UPDATE, such updates must be manually rolled out.
-  update_strategy = var.instance_group_update_strategy
-
   target_pools = var.instance_group_target_pools
   target_size  = var.cluster_size
 


### PR DESCRIPTION
Removed the `update_strategy` variable because of [this change](https://www.terraform.io/docs/providers/google/guides/version_2_upgrade.html#update_strategy-no-longer-has-any-effect-and-is-removed) in the Terraform Google Provider. 

