### PR TITLE
Fix typo in example module usage

### DIFF
--- a/modules/consul-cluster/README.md
+++ b/modules/consul-cluster/README.md
@@ -34,7 +34,7 @@ module "consul_cluster" {
   # Configure and start Consul during boot. It will automatically form a cluster with all nodes that have that
   # same tag.
   # Ensure the Consul node correctly leaves the cluster when the instance restarts or terminates.
-  startup_script = <<-EOF
+  shutdown_script = <<-EOF
               #!/bin/bash
               /opt/consul/bin/consul leave
               EOF


### PR DESCRIPTION
The module has the param `startup_script` twice instead of the `shutdown_script`