### PR TITLE
Updated to use google-beta provider for google_compute_region_instance_group_manager

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,10 @@ provider "google" {
   region = var.gcp_region
 }
 
+provider "google-beta" {
+  region = var.gcp_region
+}
+
 terraform {
   # The modules used in this example have been updated with 0.12 syntax, which means the example is no longer
   # compatible with any versions below 0.12.
@@ -72,6 +76,7 @@ module "consul_servers" {
   instance_group_update_policy_minimal_action        = "REPLACE"
   instance_group_update_policy_max_surge_fixed       = length(data.google_compute_zones.available.names)
   instance_group_update_policy_max_unavailable_fixed = 0
+  instance_group_update_policy_min_ready_sec         = 300
 }
 
 # Render the Startup Script that will run on each Consul Server Instance on boot.
@@ -129,6 +134,7 @@ module "consul_clients" {
   instance_group_update_policy_minimal_action        = "REPLACE"
   instance_group_update_policy_max_surge_fixed       = 1 * length(data.google_compute_zones.available.names)
   instance_group_update_policy_max_unavailable_fixed = 1 * length(data.google_compute_zones.available.names)
+  instance_group_update_policy_min_ready_sec         = 50
 }
 
 # Render the Startup Script that will run on each Consul Server Instance on boot.

--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,6 @@ module "consul_servers" {
   instance_group_update_policy_minimal_action        = "REPLACE"
   instance_group_update_policy_max_surge_fixed       = length(data.google_compute_zones.available.names)
   instance_group_update_policy_max_unavailable_fixed = 0
-  instance_group_update_policy_min_ready_sec         = 300
 }
 
 # Render the Startup Script that will run on each Consul Server Instance on boot.
@@ -130,7 +129,6 @@ module "consul_clients" {
   instance_group_update_policy_minimal_action        = "REPLACE"
   instance_group_update_policy_max_surge_fixed       = 1 * length(data.google_compute_zones.available.names)
   instance_group_update_policy_max_unavailable_fixed = 1 * length(data.google_compute_zones.available.names)
-  instance_group_update_policy_min_ready_sec         = 50
 }
 
 # Render the Startup Script that will run on each Consul Server Instance on boot.

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -34,7 +34,6 @@ resource "google_compute_region_instance_group_manager" "consul_server" {
     max_surge_percent            = var.instance_group_update_policy_max_surge_percent
     max_unavailable_fixed        = var.instance_group_update_policy_max_unavailable_fixed
     max_unavailable_percent      = var.instance_group_update_policy_max_unavailable_percent
-    min_ready_sec                = var.instance_group_update_policy_min_ready_sec
   }
 
   target_pools = var.instance_group_target_pools

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -14,6 +14,8 @@ terraform {
 
 # Create the Regional Managed Instance Group where Consul Server will live.
 resource "google_compute_region_instance_group_manager" "consul_server" {
+  provider = google-beta
+
   project = var.gcp_project_id
   name    = "${var.cluster_name}-ig"
 
@@ -34,6 +36,7 @@ resource "google_compute_region_instance_group_manager" "consul_server" {
     max_surge_percent            = var.instance_group_update_policy_max_surge_percent
     max_unavailable_fixed        = var.instance_group_update_policy_max_unavailable_fixed
     max_unavailable_percent      = var.instance_group_update_policy_max_unavailable_percent
+    min_ready_sec                = var.instance_group_update_policy_min_ready_sec
   }
 
   target_pools = var.instance_group_target_pools

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -187,12 +187,6 @@ variable "instance_group_update_policy_max_unavailable_percent" {
   default     = null
 }
 
-variable "instance_group_update_policy_min_ready_sec" {
-  description = "Minimum number of seconds to wait for after a newly created instance becomes available. This value must be between 0-3600."
-  type        = number
-  default     = 300
-}
-
 # Metadata
 
 variable "metadata_key_name_for_cluster_size" {

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -187,6 +187,12 @@ variable "instance_group_update_policy_max_unavailable_percent" {
   default     = null
 }
 
+variable "instance_group_update_policy_min_ready_sec" {
+  description = "Minimum number of seconds to wait for after a newly created instance becomes available. This value must be between 0-3600."
+  type        = number
+  default     = 300
+}
+
 # Metadata
 
 variable "metadata_key_name_for_cluster_size" {


### PR DESCRIPTION
Updated to use the google-beta provider for google_compute_region_instance_group_manager as this broke the repo when using hashicorp/google with release 4.0.0.
https://github.com/hashicorp/terraform-provider-google/pull/10410

Linked to issue: #66.